### PR TITLE
Add space after comma.

### DIFF
--- a/R/format_path.R
+++ b/R/format_path.R
@@ -127,11 +127,12 @@ split_path <- function(text, fns = c("here","file.path")){
         stringr::str_extract_all(paste0(func,"\\(.+?\\)")) %>%
         unlist() %>%
         # Replace forward slashes
-        stringr::str_replace_all("/", "\",\"") %>%
+        stringr::str_replace_all("/", "\", \"") %>%
         # Replace back slashes
-        stringr::str_replace_all("\\\\", "\",\"") %>%
+        # Replace back slashes
+        stringr::str_replace_all("\\\\", "\", \"") %>%
         # Replace empty commas ("") created by leading or trailing slashes
-        stringr::str_replace_all(",\"\"","")
+        stringr::str_replace_all(", \"\"","")
     }
 
     text <-

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,7 +38,7 @@ here::here("data\2020\06\01\data.csv")
 
 # becomes
 
-here::here("data","2020","06","01","data.csv")
+here::here("data", "2020", "06", "01", "data.csv")
 ```
 
 ![](demo.gif)

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ here::here("data\2020\06\01\data.csv")
 
 # becomes
 
-here::here("data","2020","06","01","data.csv")
+here::here("data", "2020", "06", "01", "data.csv")
 ```
 
 ![](demo.gif)
 
 This functionality is available via the `format_path()` function, but is
 designed to work best via an RStudio AddIn - simply highlight your
-entire function call (i.e. “here(” to “)” inclusive)\[1\], browse to the
+entire function call (i.e. “here(” to “)” inclusive)[1], browse to the
 `pathformatr` section in the RStudio Addins drop-down menu, and select
 “Split file path into quoted and comma-separated elements.”.
 
@@ -75,14 +75,14 @@ elements.
 In addition, this project presented a good opportunity to explore three
 topics I was keen to expand my knowledge of:
 
-  - the RStudio interface (accessed via the `rstudioapi` package), in
+-   the RStudio interface (accessed via the `rstudioapi` package), in
     particular developing tests for functions that modify
     user-highlighted text/the active file;
-  - building RStudio AddIns; and
-  - `regex` syntax, particularly around the handling of slashes (“\\”
+-   building RStudio AddIns; and
+-   `regex` syntax, particularly around the handling of slashes (“\\”
     and “/”).
 
 <hr>
 
-1.  This is to prevent users (mainly me) from reformatting paths in
-    functions that do not support separator-agnostic file paths.
+[1] This is to prevent users (mainly me) from reformatting paths in
+functions that do not support separator-agnostic file paths.

--- a/tests/testthat/test_replace_path_indicator.R
+++ b/tests/testthat/test_replace_path_indicator.R
@@ -6,11 +6,11 @@ context("Check path replacement 1 - indicator")
 test_that("Check path reformatting",{
   # Check it works for here()
   expect_equal(split_path("here(\"inst/rstudio/addins.dcf\")"),
-               "here(\"inst\",\"rstudio\",\"addins.dcf\")")
+               "here(\"inst\", \"rstudio\", \"addins.dcf\")")
 
   # Check it works for file.path()
   expect_equal(split_path("file.path(\"inst/rstudio/addins.dcf\")"),
-               "file.path(\"inst\",\"rstudio\",\"addins.dcf\")")
+               "file.path(\"inst\", \"rstudio\", \"addins.dcf\")")
 
   # Check it works for random user-defined function (e.g. "test")
   expect_equal(
@@ -18,7 +18,7 @@ test_that("Check path reformatting",{
       "test(\"inst/rstudio/addins.dcf\") file.path(\"inst/rstudio/addins.dcf\")",
       fns = "test"
     ),
-    "test(\"inst\",\"rstudio\",\"addins.dcf\") file.path(\"inst/rstudio/addins.dcf\")"
+    "test(\"inst\", \"rstudio\", \"addins.dcf\") file.path(\"inst/rstudio/addins.dcf\")"
   )
 
   # Check it doesn't replace arbitrary parenthesized file paths
@@ -27,16 +27,16 @@ test_that("Check path reformatting",{
 
   # Check it works with here namespace
   expect_equal(split_path("here::here(inst/rstudio/addins.dcf)"),
-               "here::here(inst\",\"rstudio\",\"addins.dcf)")
+               "here::here(inst\", \"rstudio\", \"addins.dcf)")
 
   # Check trailing slash is replaced properly
   expect_equal(split_path("here::here(\"inst/rstudio/addins/\")"),
-               "here::here(\"inst\",\"rstudio\",\"addins\")")
+               "here::here(\"inst\", \"rstudio\", \"addins\")")
 
   # Check regex is sufficiently specific
   expect_equal(split_path("here::here(\"inst/rstudio/addins\") read.csv(\"test/test2.csv\")"),
-               "here::here(\"inst\",\"rstudio\",\"addins\") read.csv(\"test/test2.csv\")")
+               "here::here(\"inst\", \"rstudio\", \"addins\") read.csv(\"test/test2.csv\")")
 
   expect_equal(split_path("read.csv(\"test/test2.csv\")here::here(\"inst/rstudio/addins\")"),
-               "read.csv(\"test/test2.csv\")here::here(\"inst\",\"rstudio\",\"addins\")")
+               "read.csv(\"test/test2.csv\")here::here(\"inst\", \"rstudio\", \"addins\")")
 })

--- a/tests/testthat/test_replace_path_local.R
+++ b/tests/testthat/test_replace_path_local.R
@@ -6,10 +6,10 @@ context("Check path replacement - full (local only)")
 #  -- Scratch Space -- #
 # here::here("inst/rstudio/test.csv")
 # here::here("inst\rstudio\test.csv")
-# here::here("inst","rstudio","test.csv")
+# here::here("inst", "rstudio", "test.csv")
 # file.path("inst/rstudio/test.csv")
 # file.path("inst\rstudio\test.csv")
-# file.path("inst","rstudio","test.csv")
+# file.path("inst", "rstudio", "test.csv")
 #  -- Scratch Space -- #
 
 test_that("various APIs for interacting with an RStudio document work", {


### PR DESCRIPTION
Add a space after commas, so it complies with `lintr` expectations.

```r
> split_path("here::here(\"inst/rstudio/addins/\")")
[1] "here::here(\"inst\", \"rstudio\", \"addins\")"
```

